### PR TITLE
WebResourceInterface::getResponse() return type can be null

### DIFF
--- a/src/WebResourceInterface.php
+++ b/src/WebResourceInterface.php
@@ -32,7 +32,7 @@ interface WebResourceInterface
      *
      * @return ResponseInterface
      */
-    public function getResponse(): ResponseInterface;
+    public function getResponse(): ?ResponseInterface;
 
     /**
      * Return an instance with the specified uri.


### PR DESCRIPTION
Fixes #15 