### PR TITLE
WebPageInterface::getContentType should be allowed to return null

### DIFF
--- a/src/WebPageInterface.php
+++ b/src/WebPageInterface.php
@@ -12,5 +12,5 @@ interface WebPageInterface extends WebResourceInterface
      *
      * @return string
      */
-    public function getCharacterSet(): string;
+    public function getCharacterSet(): ?string;
 }


### PR DESCRIPTION
Fixes #31 